### PR TITLE
Proper property declarations. This fixes a bug which causes beacon zone ...

### DIFF
--- a/src/ios/EstimoteBeacons.h
+++ b/src/ios/EstimoteBeacons.h
@@ -3,11 +3,13 @@
 
 @interface EstimoteBeacons : CDVPlugin
 
-@property NSArray *beacons;
-@property ESTBeaconRegion* currentRegion;
-@property NSString* connectionCallbackId;
-@property NSString* firmwareUpdateProgress;
-@property ESTBeacon* connectedBeacon;
-@property NSMutableDictionary* regionWatchers;
+@property (nonatomic, strong) NSArray *beacons;
+@property (nonatomic, strong) ESTBeaconRegion* currentRegion;
+@property (nonatomic, strong) NSString* connectionCallbackId;
+@property (nonatomic, strong) NSString* firmwareUpdateProgress;
+@property (nonatomic, strong) ESTBeacon* connectedBeacon;
+@property (nonatomic, strong) NSMutableDictionary* regionWatchers;
+
 - (EstimoteBeacons*)pluginInitialize;
+
 @end


### PR DESCRIPTION
...changes to not be monitored correctly.

When I used startMonitoringForRegion method for monitoring enter/exit events for a zone, none of my callbacks were being called even when the application was open in the foreground. This commit fixes the cause of this problem.
