### PR TITLE
Updated the startMonitoringForRegion

### DIFF
--- a/src/ios/EstimoteBeacons.m
+++ b/src/ios/EstimoteBeacons.m
@@ -18,13 +18,13 @@
     self.beaconManager = [[ESTBeaconManager alloc] init];
     self.beaconManager.delegate = self;
     self.beaconManager.avoidUnknownStateBeacons = YES;
-    
+
     // create sample region object (you can additionaly pass major / minor values)
     self.currentRegion = [[ESTBeaconRegion alloc] initRegionWithIdentifier:@"EstimoteSampleRegion"];
-    
+
     // region watchers
     self.regionWatchers = [[NSMutableDictionary alloc] init];
-    
+
     return self;
 }
 
@@ -34,10 +34,10 @@
     // stop existing discovery/ranging
     [self.beaconManager stopEstimoteBeaconDiscovery];
     [self.beaconManager stopRangingBeaconsInRegion:self.currentRegion];
-    
+
     // start discovery
     [self.beaconManager startEstimoteBeaconsDiscoveryForRegion:self.currentRegion];
-    
+
     // respond to JS with OK
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
@@ -47,10 +47,10 @@
     // stop existing discovery/ranging
     [self.beaconManager stopEstimoteBeaconDiscovery];
     [self.beaconManager stopRangingBeaconsInRegion:self.currentRegion];
-    
+
     // start ranging
     [self.beaconManager startRangingBeaconsInRegion:self.currentRegion];
-    
+
     // respond to JS with OK
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
@@ -60,21 +60,23 @@
     NSString* regionid = [command.arguments objectAtIndex:0];
     id major = [command.arguments objectAtIndex:1];
     id minor = [command.arguments objectAtIndex:2];
-    
+
     if([self.regionWatchers objectForKey:regionid] != nil) {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Region with given ID is already monitored."] callbackId:command.callbackId];
     } else {
         ESTBeaconRegion* region;
-        
+
         if((NSNull *)major == [NSNull null] || (NSNull *)minor == [NSNull null]) {
             region = [[ESTBeaconRegion alloc] initRegionWithIdentifier:regionid];
         } else {
             region = [[ESTBeaconRegion alloc] initRegionWithMajor:[major intValue] minor:[minor intValue] identifier:regionid];
         }
-        
+
+        region.notifyEntryStateOnDisplay = [command.arguments objectAtIndex:3];
+
         [self.beaconManager startMonitoringForRegion:region];
         [self.beaconManager requestStateForRegion:region];
-        
+
         [self.regionWatchers setObject:command.callbackId  forKey:regionid];
     }
 }
@@ -84,7 +86,7 @@
 - (void)stopEsimoteBeaconsDiscoveryForRegion:(CDVInvokedUrlCommand*)command {
     // stop existing discovery/ranging
     [self.beaconManager stopEstimoteBeaconDiscovery];
-    
+
     // respond to JS with OK
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
@@ -92,7 +94,7 @@
 - (void)stopRangingBeaconsInRegion:(CDVInvokedUrlCommand*)command {
     // stop existing discovery/ranging
     [self.beaconManager stopRangingBeaconsInRegion:self.currentRegion];
-    
+
     // respond to JS with OK
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
@@ -102,17 +104,17 @@
 {
     NSString* regionid = [command.arguments objectAtIndex:0];
     ESTBeaconRegion* regionFound = nil;
-    
+
     for(ESTBeaconRegion* region in self.regionWatchers) {
         if([region.identifier compare:regionid]) {
             regionFound = region;
             break;
         }
     }
-    
+
     if(regionFound != nil) {
         [self.beaconManager stopMonitoringForRegion:regionFound];
-        
+
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
     } else {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Region with given ID not found."] callbackId:command.callbackId];
@@ -125,7 +127,7 @@
 {
     [self.commandDelegate runInBackground:^{
         NSMutableArray* output = [NSMutableArray array];
-        
+
         if([self.beacons count] > 0)
         {
             //convert list of beacons to a an array of simple property-value objects
@@ -133,9 +135,9 @@
                 [output addObject:[self beaconToDictionary:beacon]];
             }
         }
-        
+
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:output];
-        
+
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 }
@@ -144,14 +146,14 @@
 {
     CDVPluginResult* pluginResult = nil;
     NSInteger idx = [[command.arguments objectAtIndex:0] intValue];
-    
+
     if (idx < [self.beacons count] && idx >= 0) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                      messageAsDictionary:[self beaconToDictionary:[self.beacons objectAtIndex:idx]]];
     } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid index."];
     }
-    
+
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
@@ -186,16 +188,16 @@
     NSInteger major = [[command.arguments objectAtIndex:0] intValue];
     NSInteger minor = [[command.arguments objectAtIndex:1] intValue];
     NSString* beaconid = [command.arguments objectAtIndex:2];
-    
+
     [self.beaconManager startAdvertisingWithMajor:major withMinor:minor withIdentifier:beaconid];
-    
+
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
 
 - (void)stopVirtualBeacon:(CDVInvokedUrlCommand*)command
 {
     [self.beaconManager stopAdvertising];
-    
+
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
 
@@ -206,7 +208,7 @@
     NSInteger major = [[command.arguments objectAtIndex:0] intValue];
     NSInteger minor = [[command.arguments objectAtIndex:1] intValue];
     ESTBeacon* foundBeacon = nil;
-    
+
     if([self.beacons count] > 0)
     {
         //convert list of beacons to a an array of simple property-value objects
@@ -214,24 +216,24 @@
             ESTBeacon* currentBeacon = beacon;
             NSNumber* currentMajor = currentBeacon.major;
             NSNumber* currentMinor = currentBeacon.minor;
-            
+
             if(currentMajor == nil) {
                 currentMajor = currentBeacon.major;
             }
             if(currentMinor == nil) {
                 currentMinor = currentBeacon.minor;
             }
-            
+
             if(currentMajor == nil || currentMajor == nil) {
                 continue;
             }
-            
+
             if(minor == [currentMinor intValue] && major == [currentMajor intValue]) {
                 foundBeacon = beacon;
             }
         }
     }
-    
+
     if(foundBeacon) {
         if([foundBeacon isConnected]) {
             //beacon is already connected
@@ -255,24 +257,24 @@
 {
     NSString* macAddress = [command.arguments objectAtIndex:0];
     ESTBeacon* foundBeacon = nil;
-    
+
     if([self.beacons count] > 0)
     {
         //convert list of beacons to a an array of simple property-value objects
         for (id beacon in self.beacons) {
             ESTBeacon* currentBeacon = beacon;
             NSString* currentMac = currentBeacon.macAddress;
-            
+
             if(currentMac == nil) {
                 continue;
             }
-            
+
             if([currentMac isEqualToString:macAddress]) {
                 foundBeacon = beacon;
             }
         }
     }
-    
+
     if(foundBeacon) {
         if([foundBeacon isConnected]) {
             //beacon is already connected
@@ -298,19 +300,19 @@
 {
     [self.commandDelegate runInBackground:^{
         CDVPluginResult* pluginResult = nil;
-        
+
         if(self.connectedBeacon != nil) {
             [self.connectedBeacon disconnectBeacon];
-            
+
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                          messageAsDictionary:[self beaconToDictionary:self.connectedBeacon]];
-            
+
             self.connectedBeacon = nil;
         } else {
             //no connected beacons
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"There are no connected beacons."];
         }
-        
+
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 }
@@ -321,10 +323,10 @@
 {
     if(self.connectedBeacon != nil) {
         NSNumber* advInterval = [command.arguments objectAtIndex:0];
-        
+
         if(advInterval != nil && [advInterval intValue] >= 80 && [advInterval intValue] <= 3200) {
-            
-            
+
+
             [self.connectedBeacon writeBeaconAdvInterval:[advInterval shortValue] withCompletion:^(unsigned short value, NSError *error) {
                 if(error != nil) {
                     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription] callbackId:command.callbackId];
@@ -332,9 +334,9 @@
                     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                                                          messageAsDictionary:[self beaconToDictionary:self.connectedBeacon]] callbackId:command.callbackId];
                 }
-                
+
             }];
-            
+
         } else {
             [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid advInterval value."] callbackId:command.callbackId];
         }
@@ -349,7 +351,7 @@
     if(self.connectedBeacon != nil) {
         NSNumber* power = [command.arguments objectAtIndex:0];
         ESTBeaconPower powerLevel;
-        
+
         switch ([power intValue]) {
             case -40:
                 powerLevel = ESTBeaconPowerLevel1;
@@ -376,7 +378,7 @@
                 powerLevel = ESTBeaconPowerLevel8;
                 break;
         }
-        
+
         if(powerLevel || powerLevel == ESTBeaconPowerLevel7) {
             [self.connectedBeacon writeBeaconPower:powerLevel withCompletion:^(ESTBeaconPower value, NSError *error) {
                 if(error != nil) {
@@ -402,7 +404,7 @@
             if(error == nil) {
                 self.firmwareUpdateProgress = value;
             }
-            
+
         }andCompletion:^(NSError *error){
             if(error == nil) {
                 [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK
@@ -410,7 +412,7 @@
             } else {
                 [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription] callbackId:command.callbackId];
             }
-            
+
             self.firmwareUpdateProgress = nil;
         }];
     } else {
@@ -437,7 +439,7 @@
     NSNumber* major = beacon.major;
     NSNumber* minor = beacon.minor;
     NSNumber* rssi = [NSNumber numberWithInt:beacon.rssi];
-    
+
     if(major == nil) {
         major = beacon.major;
     }
@@ -447,7 +449,7 @@
     if(rssi == nil) {
         rssi = [NSNumber numberWithInt:beacon.rssi];
     }
-    
+
     [props setValue:beacon.batteryLevel forKey:@"batteryLevel"];
     [props setValue:beacon.firmwareVersion forKey:@"firmwareVersion"];
     [props setValue:beacon.hardwareVersion forKey:@"hardwareVersion"];
@@ -460,21 +462,21 @@
     [props setValue:beacon.macAddress forKey:@"macAddress"];
     [props setValue:beacon.measuredPower forKey:@"measuredPower"];
     [props setValue:[NSNumber numberWithBool:beacon.isConnected] forKey:@"isConnected"];
-    
+
     if(beacon.power != nil) {
         [props setValue:[NSNumber numberWithChar:[beacon.power charValue]] forKey:@"power"];
     }
-    
+
     if(beacon != nil) {
         [props setValue:beacon.distance forKey:@"distance"];
         [props setValue:[NSNumber numberWithInt:beacon.proximity] forKey:@"proximity"];
-        
+
         if(beacon.proximityUUID != nil) {
             [props setValue:beacon.proximityUUID.UUIDString forKey:@"proximityUUID"];
         }
     }
-    
-    
+
+
     return props;
 }
 
@@ -500,7 +502,7 @@
                                                                  messageAsString:error.localizedDescription]
                                     callbackId:self.connectionCallbackId];
     }
-    
+
     self.connectionCallbackId = nil;
     self.connectedBeacon = nil;
 }
@@ -511,7 +513,7 @@
                                                              messageAsDictionary:[self beaconToDictionary:self.connectedBeacon]]
                                     callbackId:self.connectionCallbackId];
     }
-    
+
     self.connectionCallbackId = nil;
 }
 
@@ -521,42 +523,36 @@
     }
 }
 
--(void)beaconManager:(ESTBeaconManager *)manager
-      didEnterRegion:(ESTBeaconRegion *)region
-{
-    NSString* callbackId = [self.regionWatchers objectForKey:region.identifier];
-    
-    if(callbackId != nil) {
-        NSMutableDictionary* props = [NSMutableDictionary dictionaryWithCapacity:4];
-        
-        [props setValue:region.identifier forKey:@"id"];
-        [props setValue:region.major forKey:@"major"];
-        [props setValue:region.minor forKey:@"minor"];
-        [props setValue:@"enter" forKey:@"action"];
-        
-        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:props];
-        [result setKeepCallback:[NSNumber numberWithBool:YES]];
-        
-        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
-    }
-}
+- (void)beaconManager:(ESTBeaconManager *)manager didDetermineState:(CLRegionState)state forRegion:(ESTBeaconRegion *)region {
+    NSString *result = nil;
 
--(void)beaconManager:(ESTBeaconManager *)manager
-       didExitRegion:(ESTBeaconRegion *)region
-{
+    switch(state) {
+        case CLRegionStateUnknown:
+            result = @"unknown";
+            break;
+        case CLRegionStateInside:
+            result = @"enter";
+            break;
+        case CLRegionStateOutside:
+            result = @"exit";
+            break;
+        default:
+            result = @"unknown";
+    }
+
     NSString* callbackId = [self.regionWatchers objectForKey:region.identifier];
-    
+
     if(callbackId != nil) {
         NSMutableDictionary* props = [NSMutableDictionary dictionaryWithCapacity:4];
-        
+
         [props setValue:region.identifier forKey:@"id"];
         [props setValue:region.major forKey:@"major"];
         [props setValue:region.minor forKey:@"minor"];
-        [props setValue:@"exit" forKey:@"action"];
-        
+        [props setValue:result forKey:@"action"];
+
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:props];
         [result setKeepCallback:[NSNumber numberWithBool:YES]];
-        
+
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];
     }
 }

--- a/www/EstimoteBeacons.js
+++ b/www/EstimoteBeacons.js
@@ -77,11 +77,12 @@ EstimoteBeacons.prototype.stopRangingBeaconsInRegion = function (successCallback
     );
 };
 
-EstimoteBeacons.prototype.startMonitoringForRegion = function (id, majorOrCallback, minorOrCallback, successCallback, errorCallback) {
+EstimoteBeacons.prototype.startMonitoringForRegion = function (id, majorOrCallback, minorOrCallback, successCallback, errorCallback, notifyEntryStateOnDisplay) {
     var major = (typeof majorOrCallback === 'function') ? null : majorOrCallback;
     var minor = (typeof minorOrCallback === 'function') ? null : minorOrCallback;
     successCallback = (typeof majorOrCallback === 'function') ? majorOrCallback : successCallback;
     errorCallback = (typeof minorOrCallback === 'function') ? minorOrCallback : errorCallback;
+    var notify = (notifyEntryStateOnDisplay === true) ? true : false;
 
     if (errorCallback === null) {
         errorCallback = function () {
@@ -117,7 +118,7 @@ EstimoteBeacons.prototype.startMonitoringForRegion = function (id, majorOrCallba
         errorCallback,
         "EstimoteBeacons",
         "startMonitoringForRegion",
-        [id, major, minor]
+        [id, major, minor, notify]
     );
 };
 


### PR DESCRIPTION
Overall this provide more constant monitoring for regions and the ability to turn on the notifyEntryStateOnDisplay
-Updated the startMonitoringForRegion to use the didDetermineState
instead of didEnterRegion and didExitRegion (didDetermineState allows
for notifyEntryStateOnDisplay to fire)
-didDetermineState also provides an initial call to check if you are within a region when you call the startMonitoringForRegion, instead of just waiting until you cross a region for the first report
-Added a notifyEntryStateOnDisplay parameter to the
startMonitoringForRegion on JS to allow for more frequent in region
monitoring on the background
