### PR TITLE
Fixes: Error Domain=kCLErrorDomain Code=5 on ios9

### DIFF
--- a/plugin/src/ios/EstimoteBeacons.m
+++ b/plugin/src/ios/EstimoteBeacons.m
@@ -802,9 +802,6 @@
 
 	// Start monitoring.
 	[aManager startMonitoringForRegion:region];
-
-	// This will get the initial state faster.
-	[aManager requestStateForRegion:region];
 }
 
 /**


### PR DESCRIPTION
On iOS9 calling requestStateForRegion on aManager causes an kCLErrorDomain error with code 5. I suspect this is a problem with the Estimote SDK on iOS9 but can't be sure. 

This changed has been tested on multiple devices including iOS8 and fixes the issue. Also, it seems to actually solve other problems as well, iOS had the problem that before it actually detected the region it got a state 'unknown' then left the region before it ended up actually entering it, that problem is solved as well.

Thanks,

Thomas Cremers