### PR TITLE
Replace hyper.log by console.log

### DIFF
--- a/examples/beacon-finder/www/js/app.js
+++ b/examples/beacon-finder/www/js/app.js
@@ -30,7 +30,7 @@ var app = (function()
 	function onDeviceReady()
 	{
 		// TODO: Add functionality if needed.
-		hyper.log('onDeviceReady')
+		console.log('onDeviceReady')
 	}
 
 	// ------------- Application functions ------------- //


### PR DESCRIPTION
Throws an `Uncaught ReferenceError: hyper is not defined` error otherwise.