### PR TITLE
[WIP]Initial runtime permissions for android

### DIFF
--- a/examples/beacon-finder/www/js/screen-monitor-regions.js
+++ b/examples/beacon-finder/www/js/screen-monitor-regions.js
@@ -41,13 +41,17 @@
 		$('#id-screen-monitor-regions .style-item-list').empty();
 
 		// Request authorisation.
-		estimote.beacons.requestAlwaysAuthorization();
+		estimote.beacons.requestAlwaysAuthorization(function(){
+			// Start monitoring.
+			estimote.beacons.startMonitoringForRegion(
+				{}, // Empty region matches all beacons.
+				onMonitor,
+				onError);
+		}, function(e){
+			alert(e);
+		});
 
-		// Start monitoring.
-		estimote.beacons.startMonitoringForRegion(
-			{}, // Empty region matches all beacons.
-			onMonitor,
-			onError);
+
 	};
 
 	app.stopMonitoringRegions = function()

--- a/examples/beacon-finder/www/js/screen-range-beacons.js
+++ b/examples/beacon-finder/www/js/screen-range-beacons.js
@@ -56,13 +56,17 @@
 		$('#id-screen-range-beacons .style-item-list').empty();
 
 		// Request authorisation.
-		estimote.beacons.requestAlwaysAuthorization();
+		estimote.beacons.requestAlwaysAuthorization(function(){
+			// Start ranging.
+			estimote.beacons.startRangingBeaconsInRegion(
+				{}, // Empty region matches all beacons.
+				onRange,
+				onError);
+		}, function(e){
+			alert(e);	// An error occured, like permission denied
+		});
 
-		// Start ranging.
-		estimote.beacons.startRangingBeaconsInRegion(
-			{}, // Empty region matches all beacons.
-			onRange,
-			onError);
+
 	};
 
 	app.stopRangingBeacons = function()

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,7 @@
 		<config-file target="AndroidManifest.xml" parent="/manifest">
 			<uses-permission android:name="android.permission.BLUETOOTH" />
 			<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 		</config-file>
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
 			<service android:name="com.estimote.sdk.service.BeaconService" android:exported="false"/>


### PR DESCRIPTION
Initial implementation for https://github.com/evothings/phonegap-estimotebeacons/issues/110
Based on https://cordova.apache.org/docs/en/dev/guide/platforms/android/plugin.html

Current problems:
- [ ] request is not blocking, so the callbacks need to be used. But these are not working on all versions. I suggest that, when the function is not available (eg ios7), it always executes the success callback. This is a breaking change however.
- [ ] I only changed 2 examples to use the callback yet.
- [ ] Code style is messed up from switchting editors, but hope you get the idea :(